### PR TITLE
Amending StackExchangeAPIWrapper to return only first 3 entries.

### DIFF
--- a/libs/langchain/langchain/utilities/stackexchange.py
+++ b/libs/langchain/langchain/utilities/stackexchange.py
@@ -26,19 +26,24 @@ class StackExchangeAPIWrapper:
         return values
 
     def run(self, title: str) -> str:
-        """Run query through StackExchange API and parse results."""
-        output = self.stackapi_client.fetch('search/excerpts', title=title)
+    """Run query through StackExchange API and parse results."""
+    output = self.stackapi_client.fetch('search/excerpts', title=title)
 
-        result_text = ""
-        for ans in output['items']:
-            if ans['item_type'] == 'question':
-                result_text += f"Title: {ans['title']}\n"
-                if ans['answer_count'] > 0:
-                    index = output['items'].index(ans)
-                    result_text += f"Answer: {html.unescape(output['items'][index + 1]['excerpt'])}\n"
-                result_text += "\n"
+    result_text = ""
+    count = 0  # Track the number of results processed
+    for ans in output['items']:
+        if count >= 3:  # Limit the number of results to 3
+            break
 
-        if not result_text:
-            result_text = f"No relevant results found for '{title}' on Stack Overflow"
+        if ans['item_type'] == 'question':
+            result_text += f"Title: {ans['title']}\n"
+            if ans['answer_count'] > 0:
+                index = output['items'].index(ans)
+                result_text += f"Answer: {html.unescape(output['items'][index + 1]['excerpt'])}\n"
+            result_text += "\n"
+            count += 1
 
-        return result_text
+    if not result_text:
+        result_text = f"No relevant results found for '{title}' on Stack Overflow"
+
+    return result_text


### PR DESCRIPTION
## Summary of Changes
- This commit modifies the run() method within the Stack Exchange API wrapper to restrict the output to the first three search results.

## Details of Changes
- Introduced a count mechanism to limit the loop iteration and output to the first three entries.
- Updated the run() function to break out of the loop once three relevant results are collected, ensuring a maximum of three entries in the returned text.

## Reasoning or Justification
- This adjustment aims to provide a more concise and focused presentation of search results, limiting the displayed content to the most relevant three entries. It enhances the user experience by offering a more targeted and manageable output for search queries.

## Testing Approach
- No changes were made to the testing approach for this specific alteration. 

## Impact or Benefits
- Improves the readability and usability of the Stack Exchange API wrapper by limiting the number of search results displayed.