### PR TITLE
Adding documentation about stackexchange

### DIFF
--- a/docs/docs/integrations/providers/stackexchange.mdx
+++ b/docs/docs/integrations/providers/stackexchange.mdx
@@ -1,0 +1,36 @@
+# Stack Exchange
+
+>[Stack Exchange](https://en.wikipedia.org/wiki/Stack_Exchange) is a network of 
+question-and-answer (Q&A) websites on topics in diverse fields, each site covering 
+a specific topic, where questions, answers, and users are subject to a reputation award process.
+
+This page covers how to use the `Stack Exchange API` within LangChain.
+
+## Installation and Setup
+- Install requirements with 
+```bash
+pip install stackapi
+```
+
+## Wrappers
+
+### Utility
+
+There exists a StackExchangeAPIWrapper utility which wraps this API. To import this utility:
+
+```python
+from langchain.utilities import StackExchangeAPIWrapper
+```
+
+For a more detailed walkthrough of this wrapper, see [this notebook](/docs/integrations/tools/stackexchange).
+
+### Tool
+
+You can also easily load this wrapper as a Tool (to use with an Agent).
+You can do this with:
+```python
+from langchain.agents import load_tools
+tools = load_tools(["stackexchange"])
+```
+
+For more information on tools, see [this page](/docs/modules/agents/tools/).

--- a/docs/docs/integrations/tools/stackexchange.ipynb
+++ b/docs/docs/integrations/tools/stackexchange.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# StackExchange\n",
+    "\n",
+    "This notebook goes over how to use the stack exchange component.\n",
+    "\n",
+    "All you need to do is install stackapi:\n",
+    "1. pip install stackapi\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pip install stackapi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.utilities import StackExchangeAPIWrapper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stackexchange = StackExchangeAPIWrapper()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stackexchange.run(\"zsh: command not found: python\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Summary of Changes
This PR introduces adds documentation for new utility and tool.

Details of Changes
Added 2 documents.

Testing Approach
No tests

Impact or Benefits
Give details about how to run the new integration(StackExchange).
See contribution guidelines for more information on how to write/run tests, lint, etc:
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:

a test for the integration, preferably unit tests that do not rely on network access,
an example notebook showing its use. It lives in docs/extras directory.
If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
-->

See contribution guidelines for more information on how to write/run tests, lint, etc: 
https://github.com/langchain-ai/langchain/blob/master/.github/CONTRIBUTING.md

If you're adding a new integration, please include:
  1. a test for the integration, preferably unit tests that do not rely on network access,
  2. an example notebook showing its use. It lives in `docs/extras` directory.

If no one reviews your PR within a few days, please @-mention one of @baskaryan, @eyurtsev, @hwchase17.
 -->
